### PR TITLE
POST content must be empty when the body is empty

### DIFF
--- a/src/keosd-sock.ts
+++ b/src/keosd-sock.ts
@@ -17,7 +17,7 @@ export const sockCall = async ({
     const client = net.createConnection(wallet_url);
 
     client.on('connect', () => {
-      const bodyString = JSON.stringify(body);
+      const bodyString = body.length > 0 ? JSON.stringify(body) : '';
       let s = '';
       s += `POST ${endpoint} HTTP/1.0\r\n`;
       s += `Host: ${wallet_url}:\r\n`;


### PR DESCRIPTION
Old version sent `""` as content and leap 3.x keosd does not accept that